### PR TITLE
Publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Linter for OpenAPI definitions to check compliance to AEPs",
   "main": "dist/ruleset.js",
+  "module": "dist/ruleset.mjs",
+  "types": "dist/ruleset.d.ts",
+  "files": [
+      "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "type-check": "tsc --noEmit --noErrorTruncation --pretty false --incremental false",


### PR DESCRIPTION
Since #3 migrated the ruleset to typescript, it needs to transpiled from typescript to javascript before it can be used. Also versioning would be nice, hence publishing to npm would be useful.

after installing using e.g. `yarn add ---dev aep-openapi-linter`, you could then run
```sh
yarn run spectral lint -r node_modules/aep-openapi-linter/dist/ruleset.js [DOCUMENTS]
```

The only way I see to currently use it is to:
```
yarn add --dev aep-openapi-linter@https://github.com/aep-dev/aep-openapi-linter
cd node_modules/aep-openapi-linter
npm run build
```