### PR TITLE
Add rules for aep-131

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,8 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 12,
   },
-  rules: {},
+  rules: {
+    // set max line length to 120
+    'max-len': ['error', { code: 120 }],
+  },
 };

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,12 +1,9 @@
 ---
-printWidth: 79
+printWidth: 120
 proseWrap: always
 overrides:
   - files: '*.md.j2'
     options:
       parser: markdown
-  - files: '*.yaml'
-    options:
-      printWidth: 120
 singleQuote: true
 trailingComma: es5

--- a/aep/0131.yaml
+++ b/aep/0131.yaml
@@ -29,7 +29,7 @@ rules:
           properties:
             operationId:
               type: string
-              pattern: '^(:|[Gg][Ee][Tt][A-Z]).*$'
+              pattern: '^[Gg][Ee][Tt][A-Z].*$'
           required: ['operationId']
 
   aep-131-response-schema:

--- a/aep/0131.yaml
+++ b/aep/0131.yaml
@@ -1,0 +1,46 @@
+aliases:
+  GetOperation:
+    description: A Get operation is a get on path that ends in a path parameter
+    targets:
+      - formats: ['oas2', 'oas3']
+        given:
+          - $.paths[?(@path.match(/\}']$/))].get
+rules:
+  aep-131-http-body:
+    description: A get operation must not accept a request body.
+    severity: error
+    formats: ['oas3']
+    given:
+      - '#GetOperation.requestBody'
+    then:
+      function: falsy
+
+  aep-131-operation-id:
+    description: Verifies that the operation ID is of the form getresource
+    message: The operation ID does not conform to AEP-131
+    severity: error
+    formats: ['oas2', 'oas3']
+    given: '#GetOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            operationId:
+              type: string
+              pattern: '^(:|[Gg][Ee][Tt][A-Z]).*$'
+          required: ['operationId']
+
+  aep-131-response-schema:
+    description: Verifies that the response is an AEP resource.
+    message: The response body is not an AEP resource.
+    severity: error
+    formats: ['oas3']
+    given: '#GetOperation.responses.200.content[*].schema'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['x-aep-resource']

--- a/docs/0131.md
+++ b/docs/0131.md
@@ -1,0 +1,166 @@
+# Rules for AEP-131: Standard Get method
+
+[aep-131]: https://aep.dev/131
+
+## Get methods: No HTTP body
+
+This rule enforces that all standard `Get` operations omit the HTTP `body`, as
+mandated in [AEP-131].
+
+### Details
+
+This rule looks for "get" operations on a path that ends in a path parameter,
+and complains if the 'requestBody' field is present.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: string
+      responses:
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      responses:
+```
+
+### Disabling
+
+**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
+nature of the protocol. The only valid way to include a body is to also use a
+different HTTP method.
+
+## GET methods: Operation ID
+
+This rule enforces that all standard `Get` operations have an operationId field
+and that the value begins with "get" (case insensitive).
+
+### Details
+
+This rule looks for "get" operations on a path that ends in a path parameter,
+and complains if the 'operationId' field is not present or if the value does
+not begin with "get" (case insensitive) or a ":" (for custom get methods).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  # Missing operationId
+  '/books/{id}':
+    get:
+      summary: Get book
+      responses:
+  # operationId present but does not start with "get"
+  '/publishers/{id}':
+    get:
+      summary: Get a publisher
+      operationId: FetchPublisher
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      operationId: getBook
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/books/{id}/get/operationId'
+    rules:
+      aep-131-operation-id: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.
+
+## GET methods: Response Schema
+
+This rule enforces that all standard `Get` operations have an response body
+that represents a resource.
+
+### Details
+
+This rule looks for "get" operations on a path that ends in a path parameter,
+and complains if the schema of the 200 response contains the x-aep-resource
+specification extension.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      responses:
+        '200':
+          description: A Book
+          content:
+            'application/json':
+              # Missing x-aep-resource extension
+              schema:
+                type: object
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      responses:
+        '200':
+          description: A Book
+          content:
+            'application/json':
+              # Missing x-aep-resource extension
+              schema:
+                type: object
+                'x-aep-extension':
+                  singular: book
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/books/{id}/get/responses/200/content/application/json/schema'
+    rules:
+      aep-131-response-schema: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.

--- a/docs/0132.md
+++ b/docs/0132.md
@@ -1,5 +1,7 @@
 # Rules for AEP-132: List method
 
+[aep-132]: https://aep.dev/132
+
 ## List methods: No HTTP body
 
 This rule enforces that all `List` operations omit the HTTP `body`, as mandated
@@ -42,8 +44,6 @@ paths:
 **Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
 nature of the protocol. The only valid way to include a body is to also use a
 different HTTP method (as depicted above).
-
-[aep-132]: https://aep.dev/132
 
 ## List methods: Request param types
 
@@ -163,5 +163,3 @@ overrides:
 
 If you need to violate this rule for an entire file, add an "override" to the
 Spectral rule file for the specific file without a fragment.
-
-[aep-132]: https://aep.dev/132

--- a/docs/0135.md
+++ b/docs/0135.md
@@ -1,5 +1,7 @@
 # Rules for AEP-135: Delete method
 
+[aep-135]: https://aep.dev/135
+
 ## Delete methods: No HTTP body
 
 This rule enforces that all `Delete` operations omit the HTTP `body`, as
@@ -87,5 +89,3 @@ paths:
 
 Use the "overrides" field of the ruleset file to override a specific instance.
 Include a comment explaining why the pattern could not be followed.
-
-[aep-135]: https://aep.dev/135

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,4 +1,5 @@
 # Ruleset for AEP OpenAPI Linter
 
+- [Rules for AEP-131](./0131.md)
 - [Rules for AEP-132](./0132.md)
 - [Rules for AEP-135](./0135.md)

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -1,5 +1,6 @@
 extends:
   - spectral:oas
+  - ./aep/0131.yaml
   - ./aep/0132.yaml
   - ./aep/0135.yaml
 functionsDir: './functions'

--- a/test/0131/http-body.test.js
+++ b/test/0131/http-body.test.js
@@ -1,0 +1,83 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0131', 'aep-131-http-body');
+  return linter;
+});
+
+test('aep-131-http-body should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1/{id}.get.requestBody');
+  });
+});
+
+test('aep-131-http-body should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {},
+      },
+      '/test3/{id}': {
+        post: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        put: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        patch: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0131/operation-id.test.js
+++ b/test/0131/operation-id.test.js
@@ -49,7 +49,12 @@ test('aep-131-operation-id should find no errors', () => {
           operationId: 'GetTest',
         },
       },
-      '/test3/{id}': {
+      '/test3': {
+        get: {
+          operationId: 'ListTest',
+        },
+      },
+      '/test4/{id}:fetch': {
         get: {
           operationId: ':fetch',
         },

--- a/test/0131/operation-id.test.js
+++ b/test/0131/operation-id.test.js
@@ -1,0 +1,62 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0131', 'aep-131-operation-id');
+  return linter;
+});
+
+test('aep-131-operation-id should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+          },
+        },
+      },
+      '/test2/{id}': {
+        get: {
+          operationId: 'random',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1/{id}.get');
+    expect(paths).toContain('paths./test2/{id}.get.operationId');
+  });
+});
+
+test('aep-131-operation-id should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          operationId: 'getTest',
+        },
+      },
+      '/test2/{id}': {
+        get: {
+          operationId: 'GetTest',
+        },
+      },
+      '/test3/{id}': {
+        get: {
+          operationId: ':fetch',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0131/response-schema.test.js
+++ b/test/0131/response-schema.test.js
@@ -1,0 +1,96 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0131', 'aep-131-response-schema');
+  return linter;
+});
+
+test('aep-131-response-schema should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          responses: {
+            200: {
+              description: 'success',
+              content: {
+                'application/json': {
+                  // no x-aep-extension
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain(
+      'paths./test1/{id}.get.responses.200.content.application/json.schema'
+    );
+  });
+});
+
+test('aep-131-response-schema should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          responses: {
+            200: {
+              description: 'success',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': {
+                      singular: 'User',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test2/{id}': {
+        get: {
+          responses: {
+            200: {
+              description: 'success',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Test2',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Test2: {
+          type: 'object',
+          'x-aep-resource': {
+            singular: 'Test2',
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0131/response-schema.test.js
+++ b/test/0131/response-schema.test.js
@@ -28,14 +28,43 @@ test('aep-131-response-schema should find errors', () => {
           },
         },
       },
+      '/test2/{id}': {
+        get: {
+          responses: {
+            200: {
+              description: 'success',
+              content: {
+                'application/json': {
+                  // no x-aep-extension
+                  schema: {
+                    $ref: '#/components/schemas/Test2',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Test2: {
+          type: 'object',
+          // no x-aep-extension
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(1);
+    expect(results.length).toBe(2);
     const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain(
-      'paths./test1/{id}.get.responses.200.content.application/json.schema'
-    );
+    expect(paths).toContain('paths./test1/{id}.get.responses.200.content.application/json.schema');
+    expect(paths).toContain('paths./test2/{id}.get.responses.200.content.application/json.schema');
   });
 });
 


### PR DESCRIPTION
This PR adds three rules for aep-131:
- aep-131-http-body: A get operation must not accept a request body.
- aep-131-operation-id: Verifies that the operation ID is of the form getresource or starts with ":"
- aep-131-response-schema: Verifies that the response is an AEP resource.

Tests and docs are included.

There are also a few minor fixes / improvements in here that didn't seem worth doing in their own PR.