### PR TITLE
Implement rules for AEP-133 Standard Create method

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,9 @@
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "firsttris.vscode-jest-runner",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "42crunch.vscode-openapi",
+    "stoplight.spectral"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -14,6 +14,24 @@ rules:
     formats: ['oas2', 'oas3']
     given:
       - '#CreateOperation.parameters[?(@.in != "path")]'
+      - '#CreateOperation^.parameters[?(@.in != "path")]' # parameters at path item level
     then:
       field: required
       function: falsy
+
+  aep-133-unknown-optional-params:
+    description: A create operation should not have unknown optional parameters.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given:
+      - '#CreateOperation.parameters[?(@.in == "query")]' # only check query parameters
+      - '#CreateOperation^.parameters[?(@.in == "query")]' # parameters at path item level
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+              enum: ['id']

--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -1,0 +1,19 @@
+aliases:
+  CreateOperation:
+    description: A create operation is a post on path without a ":" in the final segment
+    targets:
+      - formats: ['oas2', 'oas3']
+        given:
+          # @property is the key of the object in the paths object
+          - $.paths[?(!@property.match(/:[^/]*$/))].post
+
+rules:
+  aep-133-required-params:
+    description: A create operation must not have any required parameters other than path parameters.
+    severity: error
+    formats: ['oas2', 'oas3']
+    given:
+      - '#CreateOperation.parameters[?(@.in != "path")]'
+    then:
+      field: required
+      function: falsy

--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -8,6 +8,79 @@ aliases:
           - $.paths[?(!@property.match(/:[^/]*$/))].post
 
 rules:
+  aep-133-id-parameter:
+    description: A create operation should have an id parameter.
+    message: The id parameter is missing.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given:
+      - '#CreateOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['parameters']
+          properties:
+            parameters:
+              type: array
+              contains:
+                type: object
+                required: ['name']
+                properties:
+                  name:
+                    enum: ['id']
+
+  aep-133-param-types:
+    description: The id parameter should be a query parameter of type string.
+    severity: error
+    formats: ['oas2', 'oas3']
+    given:
+      - '#CreateOperation.parameters[?(@.name == "id")]'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['in', 'schema']
+          properties:
+            in:
+              enum: ['query']
+            schema:
+              type: object
+              required: ['type']
+              properties:
+                type:
+                  type: string
+                  enum: ['string']
+
+  aep-133-request-body:
+    description: A standard create method must accept the resource in the request body.
+    message: The request body is not an AEP resource.
+    severity: error
+    formats: ['oas3']
+    given: '#CreateOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['requestBody']
+          properties:
+            requestBody:
+              type: object
+              required: ['content']
+              properties:
+                content:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    required: ['schema']
+                    properties:
+                      schema:
+                        type: object
+                        required: ['x-aep-resource']
+
   aep-133-required-params:
     description: A create operation must not have any required parameters other than path parameters.
     severity: error
@@ -18,6 +91,44 @@ rules:
     then:
       field: required
       function: falsy
+
+  aep-133-response-body:
+    description: The success response for a create operation must be the created AEP resource.
+    message: The response body is not an AEP resource.
+    severity: error
+    formats: ['oas3']
+    given: '#CreateOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['responses']
+          properties:
+            responses:
+              type: object
+              anyOf:
+                - required: ['200']
+                - required: ['201']
+              properties:
+                '200':
+                  $ref: '#/definitions/response'
+                '201':
+                  $ref: '#/definitions/response'
+          definitions:
+            response:
+              type: object
+              required: ['content']
+              properties:
+                content:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    required: ['schema']
+                    properties:
+                      schema:
+                        type: object
+                        required: ['x-aep-resource']
 
   aep-133-unknown-optional-params:
     description: A create operation should not have unknown optional parameters.

--- a/docs/0133.md
+++ b/docs/0133.md
@@ -2,19 +2,138 @@
 
 [AEP-133]: https://aep.dev/133
 
-## Create methods: No required parameters other than path parameters
+## Create method should allow the user to specify the ID component of the resource
 
-This rule checks that Create methods have no required parameters other than
-path parameters, as mandated in [AEP-133].
+This rule enforces that declarative-friendly create methods include a client-specified ID query parameter, as mandated
+in [AEP-133].
 
 ### Details
 
-This rule looks at the parameters of "post" operations on a path that does not
-have a ":" in its final segment (indicating a custom operation), and complains
-if it finds any required parameters that are not path parameters (which must be
-required).
+**Rule**: aep-133-id-parameter
 
-## Examples
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if there is no parameter with the name `id`.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      description: 'No parameters'
+  '/test2':
+    post:
+      description: 'No id parameter'
+      parameters:
+        - name: force
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Ok
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/book':
+    post:
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: string
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post'
+    rules:
+      aep-133-id-parameter: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## The id parameter must be a query parameter
+
+This rule checks that the id parameter is a query parameter, as mandated in [AEP-133].
+
+### Details
+
+**Rule**: aep-133-param-types
+
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if the parameter with name of "id" is not a query parameter with type
+string.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: id
+          in: header
+          schema:
+            type: string
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: string
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-133-param-types: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## Create method must have no required parameters other than path parameters
+
+This rule checks that Create methods have no required parameters other than path parameters, as mandated in [AEP-133].
+
+### Details
+
+**Rule**: aep-133-required-params
+
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if it finds any required parameters that are not path parameters (which
+must be required).
+
+### Examples
 
 **Incorrect** code for this rule:
 
@@ -48,36 +167,36 @@ paths:
             type: boolean
 ```
 
-## Disabling
+### Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
   - files:
       - 'openapi.json#/paths/test1/post/parameters/0'
     rules:
-      aep-132-request-required-params: 'off'
+      aep-133-required-params: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
 
-## Create methods: No unknown optional parameters
+## Create methods should have no unknown optional parameters
 
-This rule checks that Create methods have no optional parameters other than
-parameters defined in [AEP-133] or other AEPs.
+This rule checks that Create methods have no optional parameters other than parameters defined in [AEP-133] or other
+AEPs.
 
 ### Details
 
-This rule looks at the parameters of "post" operations on a path that does not
-have a ":" in its final segment (indicating a custom operation), and complains
-if it finds any optional query parameters that are described in the AEPs.
-Currently the only allowed optional query parameter is `id`, described in
-[AEP-133].
+**Rule**: aep-133-unknown-optional-params
 
-## Examples
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if it finds any optional query parameters that are described in the AEPs.
+Currently the only allowed optional query parameter is `id`, described in [AEP-133].
+
+### Examples
 
 **Incorrect** code for this rule:
 
@@ -110,18 +229,153 @@ paths:
             type: string
 ```
 
-## Disabling
+### Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
   - files:
       - 'openapi.json#/paths/test1/post/parameters/0'
     rules:
-      aep-132-request-unknown-optional-params: 'off'
+      aep-133-unknown-optional-params: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## A standard Create method must accept the resource in the request body
+
+This rule checks that Create methods accepts the resource to be created in the body of the request, as mandated in
+[AEP-133].
+
+### Details
+
+**Rule**: aep-133-request-body
+
+This rule looks at "post" operations on a path that does not have a ":" in its final segment (indicating a custom
+operation), and complains if there is no requestBody defined, or if the requestBody does not define a "content" with a
+schema that is an AEP resource.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      description: 'No request body'
+  '/test2':
+    post:
+      description: 'Request body is not a resource'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        200:
+          description: Ok
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books':
+    post:
+      operationId: CreateBook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              'x-aep-resource':
+                singular: book
+                plural: books
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-133-request-body: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## A standard Create method must return the resource in the response body
+
+This rule checks that Create methods return the resource in the body of the response, as mandated in [AEP-133].
+
+### Details
+
+**Rule**: aep-133-response-body
+
+This rule looks at "post" operations on a path that does not have a ":" in its final segment (indicating a custom
+operation), and complains if there is no responses defined, no 200 or 201 response, or if any response does not define a
+"content" with a schema that is an AEP resource.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      description: 'No request body'
+  '/test2':
+    post:
+      description: 'Request body is not a resource'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        200:
+          description: Ok
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books':
+    post:
+      operationId: CreateBook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              'x-aep-resource':
+                singular: book
+                plural: books
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-133-response-body: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.

--- a/docs/0133.md
+++ b/docs/0133.md
@@ -63,3 +63,65 @@ overrides:
 
 If you need to violate this rule for an entire file, add an "override" to the
 Spectral rule file for the specific file without a fragment.
+
+## Create methods: No unknown optional parameters
+
+This rule checks that Create methods have no optional parameters other than
+parameters defined in [AEP-133] or other AEPs.
+
+### Details
+
+This rule looks at the parameters of "post" operations on a path that does not
+have a ":" in its final segment (indicating a custom operation), and complains
+if it finds any optional query parameters that are described in the AEPs.
+Currently the only allowed optional query parameter is `id`, described in
+[AEP-133].
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: force
+          in: query
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/test1/{testId}/test2':
+    post:
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: string
+```
+
+## Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-132-request-unknown-optional-params: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.

--- a/docs/0133.md
+++ b/docs/0133.md
@@ -1,0 +1,65 @@
+# Rules for AEP-133: Standard Create method
+
+[AEP-133]: https://aep.dev/133
+
+## Create methods: No required parameters other than path parameters
+
+This rule checks that Create methods have no required parameters other than
+path parameters, as mandated in [AEP-133].
+
+### Details
+
+This rule looks at the parameters of "post" operations on a path that does not
+have a ":" in its final segment (indicating a custom operation), and complains
+if it finds any required parameters that are not path parameters (which must be
+required).
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: force
+          in: query
+          required: true
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/test1/{id}/test2':
+    post:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: force
+          in: query
+          schema:
+            type: boolean
+```
+
+## Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-132-request-required-params: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.

--- a/docs/0133.md
+++ b/docs/0133.md
@@ -2,14 +2,14 @@
 
 [AEP-133]: https://aep.dev/133
 
-## Create method should allow the user to specify the ID component of the resource
+## aep-133-id-parameter
+
+**Rule**: Create method should allow the user to specify the ID component of the resource.
 
 This rule enforces that declarative-friendly create methods include a client-specified ID query parameter, as mandated
 in [AEP-133].
 
 ### Details
-
-**Rule**: aep-133-id-parameter
 
 This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
 (indicating a custom operation), and complains if there is no parameter with the name `id`.
@@ -65,13 +65,13 @@ overrides:
 If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
 without a fragment.
 
-## The id parameter must be a query parameter
+## aep-133-param-types
+
+**Rule**: The id parameter must be a query parameter
 
 This rule checks that the id parameter is a query parameter, as mandated in [AEP-133].
 
 ### Details
-
-**Rule**: aep-133-param-types
 
 This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
 (indicating a custom operation), and complains if the parameter with name of "id" is not a query parameter with type
@@ -121,138 +121,14 @@ overrides:
 If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
 without a fragment.
 
-## Create method must have no required parameters other than path parameters
+## aep-133-request-body
 
-This rule checks that Create methods have no required parameters other than path parameters, as mandated in [AEP-133].
-
-### Details
-
-**Rule**: aep-133-required-params
-
-This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
-(indicating a custom operation), and complains if it finds any required parameters that are not path parameters (which
-must be required).
-
-### Examples
-
-**Incorrect** code for this rule:
-
-```yaml
-paths:
-  '/test1':
-    post:
-      parameters:
-        - name: force
-          in: query
-          required: true
-          schema:
-            type: boolean
-```
-
-**Correct** code for this rule:
-
-```yaml
-paths:
-  '/test1/{id}/test2':
-    post:
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: force
-          in: query
-          schema:
-            type: boolean
-```
-
-### Disabling
-
-If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
-file and fragment.
-
-```yaml
-overrides:
-  - files:
-      - 'openapi.json#/paths/test1/post/parameters/0'
-    rules:
-      aep-133-required-params: 'off'
-```
-
-If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
-without a fragment.
-
-## Create methods should have no unknown optional parameters
-
-This rule checks that Create methods have no optional parameters other than parameters defined in [AEP-133] or other
-AEPs.
-
-### Details
-
-**Rule**: aep-133-unknown-optional-params
-
-This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
-(indicating a custom operation), and complains if it finds any optional query parameters that are described in the AEPs.
-Currently the only allowed optional query parameter is `id`, described in [AEP-133].
-
-### Examples
-
-**Incorrect** code for this rule:
-
-```yaml
-paths:
-  '/test1':
-    post:
-      parameters:
-        - name: force
-          in: query
-          schema:
-            type: boolean
-```
-
-**Correct** code for this rule:
-
-```yaml
-paths:
-  '/test1/{testId}/test2':
-    post:
-      parameters:
-        - name: testId
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: id
-          in: query
-          schema:
-            type: string
-```
-
-### Disabling
-
-If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
-file and fragment.
-
-```yaml
-overrides:
-  - files:
-      - 'openapi.json#/paths/test1/post/parameters/0'
-    rules:
-      aep-133-unknown-optional-params: 'off'
-```
-
-If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
-without a fragment.
-
-## A standard Create method must accept the resource in the request body
+**Rule**: A standard Create method must accept the resource in the request body
 
 This rule checks that Create methods accepts the resource to be created in the body of the request, as mandated in
 [AEP-133].
 
 ### Details
-
-**Rule**: aep-133-request-body
 
 This rule looks at "post" operations on a path that does not have a ":" in its final segment (indicating a custom
 operation), and complains if there is no requestBody defined, or if the requestBody does not define a "content" with a
@@ -313,13 +189,75 @@ overrides:
 If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
 without a fragment.
 
-## A standard Create method must return the resource in the response body
+## aep-133-required-params
+
+**Rule**: Create method must have no required parameters other than path parameters
+
+This rule checks that Create methods have no required parameters other than path parameters, as mandated in [AEP-133].
+
+### Details
+
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if it finds any required parameters that are not path parameters (which
+must be required).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: force
+          in: query
+          required: true
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/test1/{id}/test2':
+    post:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: force
+          in: query
+          schema:
+            type: boolean
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-133-required-params: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## aep-133-response-body
+
+**Rule**: A standard Create method must return the resource in the response body
 
 This rule checks that Create methods return the resource in the body of the response, as mandated in [AEP-133].
 
 ### Details
-
-**Rule**: aep-133-response-body
 
 This rule looks at "post" operations on a path that does not have a ":" in its final segment (indicating a custom
 operation), and complains if there is no responses defined, no 200 or 201 response, or if any response does not define a
@@ -375,6 +313,68 @@ overrides:
       - 'openapi.json#/paths/test1/post/parameters/0'
     rules:
       aep-133-response-body: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## aep-133-unknown-optional-params
+
+**Rule**: Create methods should have no unknown optional parameters
+
+This rule checks that Create methods have no optional parameters other than parameters defined in [AEP-133] or other
+AEPs.
+
+### Details
+
+This rule looks at the parameters of "post" operations on a path that does not have a ":" in its final segment
+(indicating a custom operation), and complains if it finds any optional query parameters that are described in the AEPs.
+Currently the only allowed optional query parameter is `id`, described in [AEP-133].
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1':
+    post:
+      parameters:
+        - name: force
+          in: query
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/test1/{testId}/test2':
+    post:
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: string
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/test1/post/parameters/0'
+    rules:
+      aep-133-unknown-optional-params: 'off'
 ```
 
 If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file

--- a/test/0133/id-parameter.test.js
+++ b/test/0133/id-parameter.test.js
@@ -1,0 +1,127 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0133', 'aep-133-id-parameter');
+  return linter;
+});
+
+test('aep-133-id-parameter should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          description: 'No parameters',
+        },
+      },
+      '/test2': {
+        post: {
+          description: 'No id parameter',
+          parameters: [
+            {
+              name: 'force',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1.post');
+    expect(paths).toContain('paths./test2.post.parameters');
+  });
+});
+
+test('aep-133-id-parameter should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              name: 'id',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+      // required path parameters, optional query parameters
+      '/test1/{testId}/test2': {
+        post: {
+          parameters: [
+            {
+              name: 'testId',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'id',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+    },
+    // required params in other methods are not flagged
+    '/test3': {
+      get: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      put: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      patch: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0133/param-types.test.js
+++ b/test/0133/param-types.test.js
@@ -1,0 +1,110 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0133', 'aep-133-param-types');
+  return linter;
+});
+
+test('aep-133-param-types should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          description: 'id parameter is not query parameter',
+          parameters: [
+            {
+              name: 'id',
+              in: 'header',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+      '/test2': {
+        post: {
+          description: 'id parameter is not type string',
+          parameters: [
+            {
+              name: 'id',
+              in: 'query',
+              schema: {
+                type: 'integer',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1.post.parameters.0.in');
+    expect(paths).toContain('paths./test2.post.parameters.0.schema.type');
+  });
+});
+
+test('aep-133-param-types should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              name: 'id',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+    },
+    // id params in other methods are not flagged
+    '/test2/{id}': {
+      get: {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      put: {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      patch: {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0133/request-body.test.js
+++ b/test/0133/request-body.test.js
@@ -1,0 +1,145 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0133', 'aep-133-request-body');
+  return linter;
+});
+
+test('aep-133-request-body should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          description: 'No request body',
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+      '/test2': {
+        post: {
+          description: 'Request body that does not have content',
+          requestBody: {
+            description: 'No content',
+          },
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+      '/test3': {
+        post: {
+          description: 'Request body without x-aep-resource extension',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test4': {
+        post: {
+          description:
+            'Request body is $ref to schema without x-aep-resource extension',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Test3',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Test3: {
+          description: 'Schema without x-aep-resource extension',
+          type: 'object',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(4);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1.post');
+    expect(paths).toContain('paths./test2.post.requestBody');
+    expect(paths).toContain(
+      'paths./test3.post.requestBody.content.application/json.schema'
+    );
+    expect(paths).toContain(
+      'paths./test4.post.requestBody.content.application/json.schema'
+    );
+  });
+});
+
+test('aep-133-request-body should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  'x-aep-resource': true,
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test2': {
+        description: 'Methods other than POST are not checked',
+        get: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+        put: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        patch: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0133/required-params.test.js
+++ b/test/0133/required-params.test.js
@@ -1,0 +1,111 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0133', 'aep-133-required-params');
+  return linter;
+});
+
+test('aep-133-required-params should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              name: 'force',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    const paths = results.map(({ path }) => path.join('.'));
+    expect(paths).toContain('paths./test1.post.parameters.0.required');
+  });
+});
+
+test('aep-133-required-params should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      // No parameters
+      '/test1': {
+        get: {},
+      },
+      // required path parameters, optional query parameters
+      '/test1/{id}/test2': {
+        post: {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'force',
+              in: 'query',
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+    },
+    // required params in other methods are not flagged
+    '/test3': {
+      get: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      put: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      patch: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0133/response-body.test.js
+++ b/test/0133/response-body.test.js
@@ -1,0 +1,251 @@
+const { linterForAepRule } = require('../utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0133', 'aep-133-response-body');
+  return linter;
+});
+
+test('aep-133-response-body should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          description: 'No responses',
+          operationId: 'createTest1',
+        },
+      },
+      '/test2': {
+        post: {
+          description: 'No 200 or 201 response',
+          responses: {
+            204: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+      '/test3': {
+        post: {
+          description: 'No content in 200/201 response',
+          responses: {
+            201: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+      '/test4': {
+        post: {
+          description: 'Response body without schema',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  description: 'No schema',
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test5': {
+        post: {
+          description: 'Response body schema without x-aep-resource extension',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test6': {
+        post: {
+          description:
+            'Response body is $ref to schema without x-aep-resource extension',
+          responses: {
+            201: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Test6',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Test6: {
+          description: 'Schema without x-aep-resource extension',
+          type: 'object',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(6);
+    const paths = results.map((r) => r.path.join('.'));
+    expect(paths).toContain('paths./test1.post');
+    expect(paths).toContain('paths./test2.post.responses');
+    expect(paths).toContain('paths./test3.post.responses.201');
+    expect(paths).toContain(
+      'paths./test4.post.responses.200.content.application/json'
+    );
+    expect(paths).toContain(
+      'paths./test5.post.responses.200.content.application/json.schema'
+    );
+    expect(paths).toContain(
+      'paths./test6.post.responses.201.content.application/json.schema'
+    );
+  });
+});
+
+test('aep-133-response-body should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1': {
+        post: {
+          description: '200 response body with resource schema',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test2': {
+        post: {
+          description: '201 response body with resource schema',
+          responses: {
+            201: {
+              description: 'Created',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test3': {
+        post: {
+          description: '200 and 201 response body with resource schema',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': true,
+                  },
+                },
+              },
+            },
+            201: {
+              description: 'Created',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test4': {
+        description: 'responses other than 200/201',
+        post: {
+          description: '200 response body with resource schema',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    'x-aep-resource': true,
+                  },
+                },
+              },
+            },
+            202: {
+              description: 'Accepted',
+            },
+            400: {
+              description: 'Bad Request',
+            },
+            500: {
+              description: 'Internal Server Error',
+            },
+          },
+        },
+      },
+      '/test5': {
+        description: 'responses for other methods',
+        get: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+        put: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+        patch: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+        delete: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0133/unknown-optional-params.test.js
+++ b/test/0133/unknown-optional-params.test.js
@@ -3,11 +3,11 @@ const { linterForAepRule } = require('../utils');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForAepRule('0133', 'aep-133-required-params');
+  linter = await linterForAepRule('0133', 'aep-133-unknown-optional-params');
   return linter;
 });
 
-test('aep-133-required-params should find errors', () => {
+test('aep-133-unknown-optional-params should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -17,7 +17,6 @@ test('aep-133-required-params should find errors', () => {
             {
               name: 'force',
               in: 'query',
-              required: true,
               schema: {
                 type: 'boolean',
               },
@@ -30,7 +29,6 @@ test('aep-133-required-params should find errors', () => {
           {
             name: 'force',
             in: 'query',
-            required: true,
             schema: {
               type: 'boolean',
             },
@@ -49,12 +47,12 @@ test('aep-133-required-params should find errors', () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
     const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post.parameters.0.required');
-    expect(paths).toContain('paths./test2.parameters.0.required');
+    expect(paths).toContain('paths./test1.post.parameters.0.name');
+    expect(paths).toContain('paths./test2.parameters.0.name');
   });
 });
 
-test('aep-133-required-params should find no errors', () => {
+test('aep-133-unknown-optional-params should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -63,11 +61,11 @@ test('aep-133-required-params should find no errors', () => {
         get: {},
       },
       // required path parameters, optional query parameters
-      '/test1/{id}/test2': {
+      '/test1/{testId}/test2': {
         post: {
           parameters: [
             {
-              name: 'id',
+              name: 'testId',
               in: 'path',
               required: true,
               schema: {
@@ -75,24 +73,23 @@ test('aep-133-required-params should find no errors', () => {
               },
             },
             {
-              name: 'force',
+              name: 'id',
               in: 'query',
               schema: {
-                type: 'boolean',
+                type: 'string',
               },
             },
           ],
         },
       },
     },
-    // required params in other methods are not flagged
+    // optional params in other methods are not flagged
     '/test3': {
       get: {
         parameters: [
           {
             name: 'q',
             in: 'query',
-            required: true,
             schema: {
               type: 'string',
             },
@@ -104,7 +101,6 @@ test('aep-133-required-params should find no errors', () => {
           {
             name: 'q',
             in: 'query',
-            required: true,
             schema: {
               type: 'string',
             },
@@ -116,7 +112,6 @@ test('aep-133-required-params should find no errors', () => {
           {
             name: 'q',
             in: 'query',
-            required: true,
             schema: {
               type: 'string',
             },


### PR DESCRIPTION
This PR adds a set of rules to validate certain MUST and SHOULD conditions of AEP-133 (Standard Create method).

The rules added are:
- aep-133-id-parameter: A create operation should have an id parameter.
- aep-133-param-types: The id parameter should be a query parameter of type string.
- aep-133-request-body: A standard create method must accept the resource in the request body.
- aep-133-required-params: A create operation must not have any required parameters other than path parameters.
- aep-133-response-body:  The success response for a create operation must be the created AEP resource.
- aep-133-unknown-optional-params: A create operation should not have unknown optional parameters.
- 

The "must" rules are defined `severity: error` and "should" rules are `severity: warn`.

Documentation and tests are included.

Fixes #11