### PR TITLE
Rework existing rules/docs for consistency

### DIFF
--- a/aep/0131.yaml
+++ b/aep/0131.yaml
@@ -4,7 +4,9 @@ aliases:
     targets:
       - formats: ['oas2', 'oas3']
         given:
-          - $.paths[?(@path.match(/\}']$/))].get
+          # first condition excludes custom methods and second condition matches paths ending in a path parameter
+          - $.paths[?(!@property.match(/:[^/]*$/) && @property.match(/\}$/))].get
+
 rules:
   aep-131-http-body:
     description: A get operation must not accept a request body.
@@ -16,7 +18,7 @@ rules:
       function: falsy
 
   aep-131-operation-id:
-    description: Verifies that the operation ID is of the form getresource
+    description: The operation ID should be get{resource-singular}.
     message: The operation ID does not conform to AEP-131
     severity: error
     formats: ['oas2', 'oas3']
@@ -33,7 +35,7 @@ rules:
           required: ['operationId']
 
   aep-131-response-schema:
-    description: Verifies that the response is an AEP resource.
+    description: The response should include the AEP resource.
     message: The response body is not an AEP resource.
     severity: error
     formats: ['oas3']

--- a/aep/0131.yaml
+++ b/aep/0131.yaml
@@ -18,7 +18,7 @@ rules:
       function: falsy
 
   aep-131-operation-id:
-    description: The operation ID should be get{resource-singular}.
+    description: The operation ID should be Get{resource-singular}.
     message: The operation ID does not conform to AEP-131
     severity: error
     formats: ['oas2', 'oas3']

--- a/aep/0132.yaml
+++ b/aep/0132.yaml
@@ -18,7 +18,7 @@ rules:
       function: falsy
 
   aep-132-operation-id:
-    description: The operation ID should be list{resource-singular}.
+    description: The operation ID should be List{resource-singular}.
     message: The operation ID does not conform to AEP-132
     severity: error
     formats: ['oas2', 'oas3']

--- a/aep/0132.yaml
+++ b/aep/0132.yaml
@@ -4,7 +4,9 @@ aliases:
     targets:
       - formats: ['oas2', 'oas3']
         given:
-          - $.paths[?(!@path.match(/\}']$/))].get
+          # first condition excludes custom methods and second condition excludes paths ending in a path parameter
+          - $.paths[?(!@property.match(/:[^/]*$/) && !@property.match(/\}$/))].get
+
 rules:
   aep-132-http-body:
     description: A list operation must not accept a request body.
@@ -15,7 +17,24 @@ rules:
     then:
       function: falsy
 
-  aep-132-request-param-types:
+  aep-132-operation-id:
+    description: The operation ID should be list{resource-singular}.
+    message: The operation ID does not conform to AEP-132
+    severity: error
+    formats: ['oas2', 'oas3']
+    given: '#ListOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            operationId:
+              type: string
+              pattern: '^[Ll][Ii][Ss][Tt][A-Z].*$'
+          required: ['operationId']
+
+  aep-132-param-types:
     description: List operation must use the correct type for any optional parameters.
     severity: error
     formats: ['oas3']
@@ -81,7 +100,7 @@ rules:
                       enum: ['filter', 'order_by', 'show_deleted']
                 required: ['name']
 
-  aep-132-request-required-params:
+  aep-132-required-params:
     description: List operation should have no required parameters (except path parameters)
     severity: error
     formats: ['oas3']

--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -4,8 +4,8 @@ aliases:
     targets:
       - formats: ['oas2', 'oas3']
         given:
-          # @property is the key of the object in the paths object
-          - $.paths[?(!@property.match(/:[^/]*$/))].post
+          # first condition excludes custom methods and second condition excludes paths ending in a path parameter
+          - $.paths[?(!@property.match(/:[^/]*$/) && !@property.match(/\}$/))].post
 
 rules:
   aep-133-id-parameter:
@@ -30,6 +30,23 @@ rules:
                 properties:
                   name:
                     enum: ['id']
+
+  aep-133-operation-id:
+    description: The operation ID should be create{resource-singular}.
+    message: The operation ID does not conform to AEP-133
+    severity: error
+    formats: ['oas2', 'oas3']
+    given: '#CreateOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            operationId:
+              type: string
+              pattern: '^[Cc][Rr][Ee][Aa][Tt][Ee][A-Z].*$'
+          required: ['operationId']
 
   aep-133-param-types:
     description: The id parameter should be a query parameter of type string.

--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -32,7 +32,7 @@ rules:
                     enum: ['id']
 
   aep-133-operation-id:
-    description: The operation ID should be create{resource-singular}.
+    description: The operation ID should be Create{resource-singular}.
     message: The operation ID does not conform to AEP-133
     severity: error
     formats: ['oas2', 'oas3']

--- a/aep/0135.yaml
+++ b/aep/0135.yaml
@@ -1,19 +1,45 @@
+aliases:
+  DeleteOperation:
+    description: A Delete operation is a delete on path that ends in a path parameter
+    targets:
+      - formats: ['oas2', 'oas3']
+        given:
+          # first condition excludes custom methods and second condition matches paths ending in a path parameter
+          - $.paths[?(!@property.match(/:[^/]*$/) && @property.match(/\}$/))].delete
+
 rules:
   aep-135-http-body:
     description: A delete operation must not accept a request body.
     severity: error
     formats: ['oas3']
     given:
-      - $.paths[*].delete.requestBody
+      - '#DeleteOperation.requestBody'
     then:
       function: falsy
+
+  aep-135-operation-id:
+    description: The operation ID should be delete{resource-singular}.
+    message: The operation ID does not conform to AEP-135
+    severity: error
+    formats: ['oas2', 'oas3']
+    given: '#DeleteOperation'
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            operationId:
+              type: string
+              pattern: '^[Dd][Ee][Ll][Ee][Tt][Ee][A-Z].*$'
+          required: ['operationId']
 
   aep-135-response-204:
     description: A delete operation should have a 204 response.
     message: A delete operation should have a `204` response.
     severity: warn
     formats: ['oas2', 'oas3']
-    given: $.paths[*].delete.responses
+    given: '#DeleteOperation.responses'
     then:
       function: schema
       functionOptions:

--- a/aep/0135.yaml
+++ b/aep/0135.yaml
@@ -18,7 +18,7 @@ rules:
       function: falsy
 
   aep-135-operation-id:
-    description: The operation ID should be delete{resource-singular}.
+    description: The operation ID should be Delete{resource-singular}.
     message: The operation ID does not conform to AEP-135
     severity: error
     formats: ['oas2', 'oas3']

--- a/docs/0131.md
+++ b/docs/0131.md
@@ -2,15 +2,16 @@
 
 [aep-131]: https://aep.dev/131
 
-## Get methods: No HTTP body
+## aep-131-http-body
 
-This rule enforces that all standard `Get` operations omit the HTTP `body`, as
-mandated in [AEP-131].
+**Rule** A get method must not accept a request body.
+
+This rule enforces that all standard `Get` operations omit the HTTP `body`, as mandated in [AEP-131].
 
 ### Details
 
-This rule looks for "get" operations on a path that ends in a path parameter,
-and complains if the 'requestBody' field is present.
+This rule looks for "get" operations on a path that ends in a path parameter, and complains if the 'requestBody' field
+is present.
 
 ### Examples
 
@@ -41,20 +42,20 @@ paths:
 
 ### Disabling
 
-**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
-nature of the protocol. The only valid way to include a body is to also use a
-different HTTP method.
+**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the nature of the protocol. The only valid
+way to include a body is to also use a different HTTP method.
 
-## GET methods: Operation ID
+## aep-131-operation-id
 
-This rule enforces that all standard `Get` operations have an operationId field
-and that the value begins with "get" (case insensitive).
+**Rule**: The operation ID should be get{resource-singular}
+
+This rule enforces that all standard `Get` operations have an operationId field and that the value begins with "get"
+(case insensitive).
 
 ### Details
 
-This rule looks for "get" operations on a path that ends in a path parameter,
-and complains if the 'operationId' field is not present or if the value does
-not begin with "get" (case insensitive) or a ":" (for custom get methods).
+This rule looks for "get" operations on a path that ends in a path parameter, and complains if the 'operationId' field
+is not present or if the value does not begin with "get" (case insensitive) or a ":" (for custom get methods).
 
 ### Examples
 
@@ -86,8 +87,8 @@ paths:
 
 ### Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
@@ -97,19 +98,19 @@ overrides:
       aep-131-operation-id: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
 
-## GET methods: Response Schema
+## aep-131-response-schema
 
-This rule enforces that all standard `Get` operations have an response body
-that represents a resource.
+**Rule**: The response should include the AEP resource.
+
+This rule enforces that all standard `Get` operations have an response body that represents a resource.
 
 ### Details
 
-This rule looks for "get" operations on a path that ends in a path parameter,
-and complains if the schema of the 200 response contains the x-aep-resource
-specification extension.
+This rule looks for "get" operations on a path that ends in a path parameter, and complains if the schema of the 200
+response contains the x-aep-resource specification extension.
 
 ### Examples
 
@@ -151,8 +152,8 @@ paths:
 
 ### Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
@@ -162,5 +163,5 @@ overrides:
       aep-131-response-schema: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.

--- a/docs/0131.md
+++ b/docs/0131.md
@@ -47,15 +47,14 @@ way to include a body is to also use a different HTTP method.
 
 ## aep-131-operation-id
 
-**Rule**: The operation ID should be get{resource-singular}
+**Rule**: The operation ID should be Get{resource-singular}
 
-This rule enforces that all standard `Get` operations have an operationId field and that the value begins with "get"
-(case insensitive).
+This rule enforces that all standard `Get` methods have an operationId field with a value that begins with "Get".
 
 ### Details
 
 This rule looks for "get" operations on a path that ends in a path parameter, and complains if the 'operationId' field
-is not present or if the value does not begin with "get" (case insensitive) or a ":" (for custom get methods).
+is not present or if the value does not begin with "Get" (case insensitive) or a ":" (for custom get methods).
 
 ### Examples
 
@@ -82,7 +81,7 @@ paths:
   '/books/{id}':
     get:
       summary: Get book
-      operationId: getBook
+      operationId: GetBook
 ```
 
 ### Disabling

--- a/docs/0132.md
+++ b/docs/0132.md
@@ -47,16 +47,14 @@ way to include a body is to also use a different HTTP method (as depicted above)
 
 ## aep-132-operation-id
 
-**Rule**: The operation ID should be list{resource-plural}
+**Rule**: The operation ID should be List{resource-plural}
 
-This rule enforces that all standard `List` operations have an operationId field and that the value begins with "list"
-(case insensitive).
+This rule enforces that all standard `List` methods have an operationId field with a value that begins with "List".
 
 ### Details
 
-This rule looks for "list" operations on a path that does not end in a path parameter, and complains if the
-'operationId' field is not present or if the value does not begin with "list" (case insensitive) or a ":" (for custom
-methods).
+This rule looks for "get" operations on a path that does not end in a path parameter, and complains if the 'operationId'
+field is not present or if the value does not begin with "list" (case insensitive) or a ":" (for custom methods).
 
 ### Examples
 

--- a/docs/0132.md
+++ b/docs/0132.md
@@ -2,15 +2,16 @@
 
 [aep-132]: https://aep.dev/132
 
-## List methods: No HTTP body
+## aep-132-http-body
 
-This rule enforces that all `List` operations omit the HTTP `body`, as mandated
-in [AEP-132][].
+**Rule**: A list operation must not accept a request body.
+
+This rule enforces that all `List` operations omit the HTTP `body`, as mandated in [AEP-132][].
 
 ### Details
 
-This rule looks for "get" operations on a path that does not end in a path
-parameter, and complains if the 'requestBody' field is present.
+This rule looks for "get" operations on a path that does not end in a path parameter, and complains if the 'requestBody'
+field is present.
 
 ### Examples
 
@@ -41,19 +42,77 @@ paths:
 
 ### Disabling
 
-**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
-nature of the protocol. The only valid way to include a body is to also use a
-different HTTP method (as depicted above).
+**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the nature of the protocol. The only valid
+way to include a body is to also use a different HTTP method (as depicted above).
 
-## List methods: Request param types
+## aep-132-operation-id
 
-This rule enforces that all `List` standard methods use the correct type for
-any optional parameters described in [AEP-132][].
+**Rule**: The operation ID should be list{resource-plural}
+
+This rule enforces that all standard `List` operations have an operationId field and that the value begins with "list"
+(case insensitive).
+
+### Details
+
+This rule looks for "list" operations on a path that does not end in a path parameter, and complains if the
+'operationId' field is not present or if the value does not begin with "list" (case insensitive) or a ":" (for custom
+methods).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  # Missing operationId
+  '/books':
+    get:
+      summary: list books
+      responses:
+  # operationId present but does not start with "list"
+  '/publishers':
+    get:
+      summary: List publishers
+      operationId: GetAllPublishers
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books':
+    get:
+      summary: List books
+      operationId: listBooks
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/books/get/operationId'
+    rules:
+      aep-132-operation-id: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## aep-132-param-types
+
+**Rule**: List operation must use the correct type for any optional parameters.
+
+This rule enforces that all `List` standard methods use the correct type for any optional parameters described in
+[AEP-132][].
 
 ## Details
 
-This rule looks at the query parameters of "get" operations on a path that does
-not end in a path parameter, and complains if it finds
+This rule looks at the query parameters of "get" operations on a path that does not end in a path parameter, and
+complains if it finds
 
 - a parameter named `filter` that is not `type: string`
 - a parameter named `order_by` that is not `type: string`
@@ -89,30 +148,31 @@ paths:
 
 ## Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
   - files:
       - 'openapi.json#/paths/test1/get/parameters/0'
     rules:
-      aep-132-request-param-types: 'off'
+      aep-132-param-types: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
 
-## List methods: Required fields
+## aep-132-required-params
 
-This rule enforces that all `List` standard methods do not have unexpected
-required parameters, as mandated in [AEP-132][].
+**Rule**: List operation should have no required parameters (except path parameters)
+
+This rule enforces that all `List` standard methods do not have unexpected required parameters, as mandated in
+[AEP-132][].
 
 ### Details
 
-This rule looks at the parameters of "get" operations on a path that does not
-end in a path parameter, and complains if it finds any required parameters that
-are not path parameters (which must be required).
+This rule looks at the parameters of "get" operations on a path that does not end in a path parameter, and complains if
+it finds any required parameters that are not path parameters (which must be required).
 
 ## Examples
 
@@ -150,16 +210,16 @@ paths:
 
 ## Disabling
 
-If you need to violate this rule for a specific operation, add an "override" to
-the Spectral rule file for the specific file and fragment.
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
 
 ```yaml
 overrides:
   - files:
       - 'openapi.json#/paths/test1/get/parameters/0'
     rules:
-      aep-132-request-required-params: 'off'
+      aep-132-required-params: 'off'
 ```
 
-If you need to violate this rule for an entire file, add an "override" to the
-Spectral rule file for the specific file without a fragment.
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.

--- a/docs/0133.md
+++ b/docs/0133.md
@@ -65,6 +65,62 @@ overrides:
 If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
 without a fragment.
 
+## aep-133-operation-id
+
+**Rule**: The operation ID should be Create{resource-plural}
+
+This rule enforces that all standard `Create` methods have an operationId field with a value that begins with "Create".
+
+### Details
+
+This rule looks for "post" operations on a path that does not end in a path parameter, and complains if the
+'operationId' field is not present or if the value does not begin with "Create" (case insensitive) or a ":" (for custom
+methods).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  # Missing operationId
+  '/books':
+    post:
+      summary: Create a book
+      responses:
+  # operationId present but does not start with "Create"
+  '/publishers':
+    post:
+      summary: Create a publisher
+      operationId: MakePublisher
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books':
+    post:
+      summary: Create a book
+      operationId: CreateBook
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/books/post/operationId'
+    rules:
+      aep-133-operation-id: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
 ## aep-133-param-types
 
 **Rule**: The id parameter must be a query parameter

--- a/docs/0135.md
+++ b/docs/0135.md
@@ -2,15 +2,15 @@
 
 [aep-135]: https://aep.dev/135
 
-## Delete methods: No HTTP body
+## aep-135-http-body
 
-This rule enforces that all `Delete` operations omit the HTTP `body`, as
-mandated in [AEP-135][].
+**Rule**: A delete operation must not accept a request body.
+
+This rule enforces that all `Delete` operations omit the HTTP `body`, as mandated in [AEP-135][].
 
 ### Details
 
-This rule looks for "delete" operations and complains if the 'requestBody'
-field is present.
+This rule looks for "delete" operations and complains if the 'requestBody' field is present.
 
 ### Examples
 
@@ -41,19 +41,74 @@ paths:
 
 ### Disabling
 
-**Important:** HTTP `DELETE` requests are unable to have an HTTP body, due to
-the nature of the protocol. The only valid way to include a body is to also use
-a different HTTP method (as depicted above).
+**Important:** HTTP `DELETE` requests are unable to have an HTTP body, due to the nature of the protocol. The only valid
+way to include a body is to also use a different HTTP method (as depicted above).
 
-## Delete methods: Response 204
+## aep-135-operation-id
 
-This rule enforces that all `Delete` operations return a "204" (No Content)
-response.
+**Rule**: The operation ID should be delete{resource-singular}
+
+This rule enforces that all standard `Delete` operations have an operationId field and that the value begins with
+"delete" (case insensitive).
 
 ### Details
 
-This rule looks for "delete" operations and complains if "responses" does not
-have a "204" property.
+This rule looks for "delete" operations on a path that ends in a path parameter, and complains if the 'operationId'
+field is not present or if the value does not begin with "delete" (case insensitive) or a ":" (for custom methods).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  # Missing operationId
+  '/books/{id}':
+    delete:
+      summary: Delete book
+      responses:
+  # operationId present but does not start with "delete"
+  '/publishers/{id}':
+    delete:
+      summary: Delete a publisher
+      operationId: RemovePublisher
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    delete:
+      summary: Delete book
+      operationId: deleteBook
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to the Spectral rule file for the specific
+file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/books/{id}/delete/operationId'
+    rules:
+      aep-135-operation-id: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the Spectral rule file for the specific file
+without a fragment.
+
+## aep-135-response-204
+
+**Rule**: A delete operation should have a `204` response.
+
+This rule enforces that all `Delete` operations return a "204" (No Content) response.
+
+### Details
+
+This rule looks for "delete" operations and complains if "responses" does not have a "204" property.
 
 ### Examples
 
@@ -87,5 +142,5 @@ paths:
 
 ### Disabling
 
-Use the "overrides" field of the ruleset file to override a specific instance.
-Include a comment explaining why the pattern could not be followed.
+Use the "overrides" field of the ruleset file to override a specific instance. Include a comment explaining why the
+pattern could not be followed.

--- a/docs/0135.md
+++ b/docs/0135.md
@@ -46,15 +46,14 @@ way to include a body is to also use a different HTTP method (as depicted above)
 
 ## aep-135-operation-id
 
-**Rule**: The operation ID should be delete{resource-singular}
+**Rule**: The operation ID should be Delete{resource-singular}
 
-This rule enforces that all standard `Delete` operations have an operationId field and that the value begins with
-"delete" (case insensitive).
+This rule enforces that all standard `Delete` methods have an operationId field with a value that begins with "Delete".
 
 ### Details
 
 This rule looks for "delete" operations on a path that ends in a path parameter, and complains if the 'operationId'
-field is not present or if the value does not begin with "delete" (case insensitive) or a ":" (for custom methods).
+field is not present or if the value does not begin with "Delete" (case insensitive) or a ":" (for custom methods).
 
 ### Examples
 
@@ -65,7 +64,7 @@ paths:
   # Missing operationId
   '/books/{id}':
     delete:
-      summary: Delete book
+      summary: Delete a book
       responses:
   # operationId present but does not start with "delete"
   '/publishers/{id}':
@@ -80,8 +79,8 @@ paths:
 paths:
   '/books/{id}':
     delete:
-      summary: Delete book
-      operationId: deleteBook
+      summary: Delete a book
+      operationId: DeleteBook
 ```
 
 ### Disabling

--- a/test/0132/request-param-types.test.js
+++ b/test/0132/request-param-types.test.js
@@ -3,11 +3,11 @@ const { linterForAepRule } = require('../utils');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForAepRule('0132', 'aep-132-request-param-types');
+  linter = await linterForAepRule('0132', 'aep-132-param-types');
   return linter;
 });
 
-test('aep-132-request-param-types should find errors', () => {
+test('aep-132-param-types should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -35,7 +35,7 @@ test('aep-132-request-param-types should find errors', () => {
   });
 });
 
-test('aep-132-request-param-types should find no errors', () => {
+test('aep-132-param-types should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {

--- a/test/0132/request-required-params.test.js
+++ b/test/0132/request-required-params.test.js
@@ -3,11 +3,11 @@ const { linterForAepRule } = require('../utils');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForAepRule('0132', 'aep-132-request-required-params');
+  linter = await linterForAepRule('0132', 'aep-132-required-params');
   return linter;
 });
 
-test('aep-132-request-required-params should find errors', () => {
+test('aep-132-required-params should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -34,7 +34,7 @@ test('aep-132-request-required-params should find errors', () => {
   });
 });
 
-test('aep-132-request-required-params should find no errors', () => {
+test('aep-132-required-params should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {

--- a/test/0135/http-body.test.js
+++ b/test/0135/http-body.test.js
@@ -11,7 +11,7 @@ test('aep-135-http-body should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
-      '/test1': {
+      '/test1/{id}': {
         delete: {
           requestBody: {
             content: {
@@ -28,7 +28,7 @@ test('aep-135-http-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('paths./test1.delete.requestBody');
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.delete.requestBody');
   });
 });
 
@@ -36,10 +36,10 @@ test('aep-135-http-body should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
-      '/test1': {
+      '/test1/{id}': {
         delete: {},
       },
-      '/test3': {
+      '/test3/{id}': {
         post: {
           requestBody: {
             content: {

--- a/test/0135/response-204.test.js
+++ b/test/0135/response-204.test.js
@@ -11,7 +11,7 @@ test('aep-135-response-204 should find errors', () => {
   const myOpenApiDocument = {
     openapi: '3.0.3',
     paths: {
-      '/api/Paths': {
+      '/api/Paths/{id}': {
         delete: {
           responses: {
             200: {
@@ -24,9 +24,7 @@ test('aep-135-response-204 should find errors', () => {
   };
   return linter.run(myOpenApiDocument).then((results) => {
     expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe(
-      'paths./api/Paths.delete.responses'
-    );
+    expect(results[0].path.join('.')).toBe('paths./api/Paths/{id}.delete.responses');
   });
 });
 
@@ -34,7 +32,7 @@ test('aep-135-response-204 should find no errors', () => {
   const myOpenApiDocument = {
     openapi: '3.0.3',
     paths: {
-      '/api/Paths': {
+      '/api/Paths/{id}': {
         delete: {
           responses: {
             204: {
@@ -43,7 +41,7 @@ test('aep-135-response-204 should find no errors', () => {
           },
         },
       },
-      '/test202': {
+      '/test202/{id}': {
         delete: {
           responses: {
             202: {


### PR DESCRIPTION
This PR reworks the existing rules/docs to incorporate the structure/style of the more recent rules.

In particular:
- All rules now use an alias that excludes custom operations
- All rulesets now include an operationId rule (tests and docs added)
- Docs now use the rule name as the L2 header
- Removed "request" from rule names for parameters

There are also some changes in line length caused by changes to the prettier config.