### PR TITLE
Check results with custom matcher

### DIFF
--- a/aep/0133.yaml
+++ b/aep/0133.yaml
@@ -33,7 +33,7 @@ rules:
 
   aep-133-operation-id:
     description: The operation ID should be Create{resource-singular}.
-    message: The operation ID does not conform to AEP-133
+    message: The operation ID does not conform to AEP-133.
     severity: error
     formats: ['oas2', 'oas3']
     given: '#CreateOperation'

--- a/functions/parameter-names-unique.js
+++ b/functions/parameter-names-unique.js
@@ -39,12 +39,10 @@ module.exports = (pathItem, _opts, paths) => {
   pathDups.forEach((dup) => {
     // get the index of all names that match dup
     const dupKeys = [...pathParams.keys()].filter((k) => canonical(pathParams[k]) === dup);
-    // Refer back to the first one
-    const first = `parameters.${dupKeys[0]}`;
     // Report errors for all the others
     dupKeys.slice(1).forEach((key) => {
       errors.push({
-        message: `Duplicate parameter name (ignoring case) with ${first}.`,
+        message: `Duplicate parameter name (ignoring case): ${dup}.`,
         path: [...path, 'parameters', key, 'name'],
       });
     });
@@ -62,18 +60,13 @@ module.exports = (pathItem, _opts, paths) => {
       dups.forEach((dup) => {
         // get the index of all names that match dup
         const dupKeys = [...allParams.keys()].filter((k) => canonical(allParams[k]) === dup);
-        // Refer back to the first one - could be path or method
-        const first =
-          dupKeys[0] < pathParams.length
-            ? `parameters.${dupKeys[0]}`
-            : `${method}.parameters.${dupKeys[0] - pathParams.length}`;
         // Report errors for any others that are method parameters
         dupKeys
           .slice(1)
           .filter((k) => k >= pathParams.length)
           .forEach((key) => {
             errors.push({
-              message: `Duplicate parameter name (ignoring case) with ${first}.`,
+              message: `Duplicate parameter name (ignoring case): ${dup}.`,
               path: [...path, method, 'parameters', key - pathParams.length, 'name'],
             });
           });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@jest/globals": "^29.7.0",
         "@stoplight/spectral-core": "^1.19.4",
         "@stoplight/spectral-parsers": "^1.0.5",
         "@stoplight/spectral-ruleset-migrator": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.23.4",
     "jest": "^29.7.0",
+    "@jest/globals": "^29.7.0",
     "prettier": "^3.2.5"
   },
   "jest": {

--- a/test/0131/http-body.test.js
+++ b/test/0131/http-body.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -28,8 +29,10 @@ test('aep-131-http-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1/{id}.get.requestBody');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'get', 'requestBody'],
+      message: 'A get operation must not accept a request body.',
+    });
   });
 });
 

--- a/test/0131/operation-id.test.js
+++ b/test/0131/operation-id.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -29,9 +30,14 @@ test('aep-131-operation-id should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1/{id}.get');
-    expect(paths).toContain('paths./test2/{id}.get.operationId');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'get'],
+      message: 'The operation ID does not conform to AEP-131',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2/{id}', 'get', 'operationId'],
+      message: 'The operation ID does not conform to AEP-131',
+    });
   });
 });
 

--- a/test/0131/response-schema.test.js
+++ b/test/0131/response-schema.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -62,9 +63,14 @@ test('aep-131-response-schema should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1/{id}.get.responses.200.content.application/json.schema');
-    expect(paths).toContain('paths./test2/{id}.get.responses.200.content.application/json.schema');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'get', 'responses', '200', 'content', 'application/json', 'schema'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2/{id}', 'get', 'responses', '200', 'content', 'application/json', 'schema'],
+      message: 'The response body is not an AEP resource.',
+    });
   });
 });
 

--- a/test/0132/http-body.test.js
+++ b/test/0132/http-body.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -28,7 +29,10 @@ test('aep-132-http-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('paths./test1.get.requestBody');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'get', 'requestBody'],
+      message: 'A list operation must not accept a request body.',
+    });
   });
 });
 

--- a/test/0132/operation-id.test.js
+++ b/test/0132/operation-id.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -29,9 +30,14 @@ test('aep-132-operation-id should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.get');
-    expect(paths).toContain('paths./test2.get.operationId');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'get'],
+      message: 'The operation ID does not conform to AEP-132',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'get', 'operationId'],
+      message: 'The operation ID does not conform to AEP-132',
+    });
   });
 });
 

--- a/test/0132/param-types.test.js
+++ b/test/0132/param-types.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -30,8 +31,10 @@ test('aep-132-param-types should find errors', () => {
     // This rule currently triggers multiple times on the same parameter
     // That isn't ideal but it does trigger so for now we'll let this pass
     expect(results.length).toBeGreaterThan(1);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.get.parameters.0');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'get', 'parameters', '0', 'schema', 'type'],
+      message: 'List operation must use the correct type for any optional parameters.',
+    });
   });
 });
 

--- a/test/0132/required-params.test.js
+++ b/test/0132/required-params.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -29,8 +30,10 @@ test('aep-132-required-params should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.get.parameters.0.required');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'get', 'parameters', '0', 'required'],
+      message: 'List operation should have no required parameters (except path parameters)',
+    });
   });
 });
 

--- a/test/0133/id-parameter.test.js
+++ b/test/0133/id-parameter.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -35,9 +36,14 @@ test('aep-133-id-parameter should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post');
-    expect(paths).toContain('paths./test2.post.parameters');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post'],
+      message: 'The id parameter is missing.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'post', 'parameters'],
+      message: 'The id parameter is missing.',
+    });
   });
 });
 

--- a/test/0133/operation-id.test.js
+++ b/test/0133/operation-id.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -29,9 +30,14 @@ test('aep-133-operation-id should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post');
-    expect(paths).toContain('paths./test2.post.operationId');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post'],
+      message: 'The operation ID does not conform to AEP-133.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'post', 'operationId'],
+      message: 'The operation ID does not conform to AEP-133.',
+    });
   });
 });
 

--- a/test/0133/param-types.test.js
+++ b/test/0133/param-types.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -43,9 +44,14 @@ test('aep-133-param-types should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post.parameters.0.in');
-    expect(paths).toContain('paths./test2.post.parameters.0.schema.type');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post', 'parameters', '0', 'in'],
+      message: 'The id parameter should be a query parameter of type string.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'post', 'parameters', '0', 'schema', 'type'],
+      message: 'The id parameter should be a query parameter of type string.',
+    });
   });
 });
 

--- a/test/0133/request-body.test.js
+++ b/test/0133/request-body.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -74,11 +75,22 @@ test('aep-133-request-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(4);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post');
-    expect(paths).toContain('paths./test2.post.requestBody');
-    expect(paths).toContain('paths./test3.post.requestBody.content.application/json.schema');
-    expect(paths).toContain('paths./test4.post.requestBody.content.application/json.schema');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post'],
+      message: 'The request body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'post', 'requestBody'],
+      message: 'The request body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test3', 'post', 'requestBody', 'content', 'application/json', 'schema'],
+      message: 'The request body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test4', 'post', 'requestBody', 'content', 'application/json', 'schema'],
+      message: 'The request body is not an AEP resource.',
+    });
   });
 });
 

--- a/test/0133/required-params.test.js
+++ b/test/0133/required-params.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -48,9 +49,14 @@ test('aep-133-required-params should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post.parameters.0.required');
-    expect(paths).toContain('paths./test2.parameters.0.required');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post', 'parameters', '0', 'required'],
+      message: 'A create operation must not have any required parameters other than path parameters.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'parameters', '0', 'required'],
+      message: 'A create operation must not have any required parameters other than path parameters.',
+    });
   });
 });
 

--- a/test/0133/response-body.test.js
+++ b/test/0133/response-body.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -98,13 +99,30 @@ test('aep-133-response-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(6);
-    const paths = results.map((r) => r.path.join('.'));
-    expect(paths).toContain('paths./test1.post');
-    expect(paths).toContain('paths./test2.post.responses');
-    expect(paths).toContain('paths./test3.post.responses.201');
-    expect(paths).toContain('paths./test4.post.responses.200.content.application/json');
-    expect(paths).toContain('paths./test5.post.responses.200.content.application/json.schema');
-    expect(paths).toContain('paths./test6.post.responses.201.content.application/json.schema');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'post', 'responses'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test3', 'post', 'responses', '201'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test4', 'post', 'responses', '200', 'content', 'application/json'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test5', 'post', 'responses', '200', 'content', 'application/json', 'schema'],
+      message: 'The response body is not an AEP resource.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test6', 'post', 'responses', '201', 'content', 'application/json', 'schema'],
+      message: 'The response body is not an AEP resource.',
+    });
   });
 });
 

--- a/test/0133/unknown-optional-params.test.js
+++ b/test/0133/unknown-optional-params.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -46,9 +47,14 @@ test('aep-133-unknown-optional-params should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1.post.parameters.0.name');
-    expect(paths).toContain('paths./test2.parameters.0.name');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1', 'post', 'parameters', '0', 'name'],
+      message: 'A create operation should not have unknown optional parameters.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2', 'parameters', '0', 'name'],
+      message: 'A create operation should not have unknown optional parameters.',
+    });
   });
 });
 

--- a/test/0135/http-body.test.js
+++ b/test/0135/http-body.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -28,7 +29,10 @@ test('aep-135-http-body should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('paths./test1/{id}.delete.requestBody');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'delete', 'requestBody'],
+      message: 'A delete operation must not accept a request body.',
+    });
   });
 });
 

--- a/test/0135/operation-id.test.js
+++ b/test/0135/operation-id.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -29,9 +30,14 @@ test('aep-135-operation-id should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1/{id}.delete');
-    expect(paths).toContain('paths./test2/{id}.delete.operationId');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'delete'],
+      message: 'The operation ID does not conform to AEP-135',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2/{id}', 'delete', 'operationId'],
+      message: 'The operation ID does not conform to AEP-135',
+    });
   });
 });
 

--- a/test/0135/response-204.test.js
+++ b/test/0135/response-204.test.js
@@ -1,4 +1,5 @@
 const { linterForAepRule } = require('../utils');
+require('../matchers');
 
 let linter;
 
@@ -24,7 +25,10 @@ test('aep-135-response-204 should find errors', () => {
   };
   return linter.run(myOpenApiDocument).then((results) => {
     expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('paths./api/Paths/{id}.delete.responses');
+    expect(results).toContainMatch({
+      path: ['paths', '/api/Paths/{id}', 'delete', 'responses'],
+      message: 'A delete operation should have a `204` response.',
+    });
   });
 });
 

--- a/test/matchers.js
+++ b/test/matchers.js
@@ -1,0 +1,25 @@
+const { expect } = require('@jest/globals');
+
+// Extend jest matchers with a method to check if an array contains an object
+// that matches the expected object. Matching means that actual object contains
+// all properties of the expected object with the same values.
+function toContainMatch(actual, expected) {
+  if (!Array.isArray(actual)) {
+    throw new TypeError('Actual value must be an array!');
+  }
+
+  const index = actual.findIndex((item) =>
+    // eslint-disable-next-line implicit-arrow-linebreak
+    Object.keys(expected).every((key) => this.equals(item[key], expected[key]))
+  );
+
+  const pass = index !== -1;
+  const message = () =>
+    `expected ${this.utils.printReceived(actual)} to contain object ${this.utils.printExpected(expected)}`;
+
+  return { message, pass };
+}
+
+expect.extend({
+  toContainMatch,
+});

--- a/test/parameter-names-unique.test.js
+++ b/test/parameter-names-unique.test.js
@@ -1,4 +1,5 @@
 const { linterForRule } = require('./utils');
+require('./matchers');
 
 let linter;
 
@@ -68,11 +69,22 @@ test('aep-parameter-names-unique should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(4);
-    const paths = results.map(({ path }) => path.join('.'));
-    expect(paths).toContain('paths./test1/{p1}.parameters.1.name');
-    expect(paths).toContain('paths./test1/{p1}.get.parameters.0.name');
-    expect(paths).toContain('paths./test1/{p1}.get.parameters.1.name');
-    expect(paths).toContain('paths./test1/{p1}.get.parameters.3.name');
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{p1}', 'parameters', '1', 'name'],
+      message: 'Duplicate parameter name (ignoring case): p1.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{p1}', 'get', 'parameters', '0', 'name'],
+      message: 'Duplicate parameter name (ignoring case): p1.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{p1}', 'get', 'parameters', '1', 'name'],
+      message: 'Duplicate parameter name (ignoring case): p2.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{p1}', 'get', 'parameters', '3', 'name'],
+      message: 'Duplicate parameter name (ignoring case): p3.',
+    });
   });
 });
 


### PR DESCRIPTION
This PR adds a custom expect matcher to make the tests even more flexible and resilient to changes in the order of results. The new matcher allows checking of the message as well as the path, and any other properties that are deemed important.