### PR TITLE
New and updated rules for aep-131

### DIFF
--- a/aep/0131.yaml
+++ b/aep/0131.yaml
@@ -8,15 +8,6 @@ aliases:
           - $.paths[?(!@property.match(/:[^/]*$/) && @property.match(/\}$/))].get
 
 rules:
-  aep-131-http-body:
-    description: A get operation must not accept a request body.
-    severity: error
-    formats: ['oas3']
-    given:
-      - '#GetOperation.requestBody'
-    then:
-      function: falsy
-
   aep-131-operation-id:
     description: The operation ID should be Get{resource-singular}.
     message: The operation ID does not conform to AEP-131
@@ -34,8 +25,28 @@ rules:
               pattern: '^[Gg][Ee][Tt][A-Z].*$'
           required: ['operationId']
 
-  aep-131-response-schema:
-    description: The response should include the AEP resource.
+  aep-131-request-body:
+    description: A get operation must not accept a request body.
+    severity: error
+    formats: ['oas3']
+    given:
+      - '#GetOperation.requestBody'
+    then:
+      function: falsy
+
+  aep-131-required-params:
+    description: A standard Get method must not have any required parameters other than path parameters.
+    severity: error
+    formats: ['oas2', 'oas3']
+    given:
+      - '#GetOperation.parameters[?(@.in != "path")]'
+      - '#GetOperation^.parameters[?(@.in != "path")]' # parameters at path item level
+    then:
+      field: required
+      function: falsy
+
+  aep-131-response-body:
+    description: The response must be the AEP resource.
     message: The response body is not an AEP resource.
     severity: error
     formats: ['oas3']
@@ -46,3 +57,22 @@ rules:
         schema:
           type: object
           required: ['x-aep-resource']
+
+  aep-131-unknown-optional-params:
+    description: A standard Get method should not have unknown optional parameters.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given:
+      - '#GetOperation.parameters[?(@.in == "query")]' # only check query parameters
+      - '#GetOperation^.parameters[?(@.in == "query")]' # parameters at path item level
+    then:
+      # Use schema function on name so that the error points to the name field
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            name:
+              enum:
+                - 'read_mask' # AEP-157 Partial responses
+                - 'view' # AEP-157 Partial responses

--- a/docs/0131.md
+++ b/docs/0131.md
@@ -2,50 +2,9 @@
 
 [aep-131]: https://aep.dev/131
 
-## aep-131-http-body
-
-**Rule** A get method must not accept a request body.
-
-This rule enforces that all standard `Get` operations omit the HTTP `body`, as
-mandated in [AEP-131].
-
-### Details
-
-This rule looks for "get" operations on a path that ends in a path parameter,
-and complains if the 'requestBody' field is present.
-
-### Examples
-
-**Incorrect** code for this rule:
-
-```yaml
-paths:
-  '/books/{id}':
-    get:
-      summary: Get book
-      requestBody:
-        content:
-          'application/json':
-            schema:
-              type: string
-      responses:
-```
-
-**Correct** code for this rule:
-
-```yaml
-paths:
-  '/books/{id}':
-    get:
-      summary: Get book
-      responses:
-```
-
-### Disabling
-
-**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
-nature of the protocol. The only valid way to include a body is to also use a
-different HTTP method.
+The `aep-131` rules check the descriptions of standard Get methods, which are
+"get" operations on path that ends in a path parameter with no appended action
+(indicating a custom method).
 
 ## aep-131-operation-id
 
@@ -104,7 +63,124 @@ overrides:
 If you need to violate this rule for an entire file, add an "override" to the
 Spectral rule file for the specific file without a fragment.
 
-## aep-131-response-schema
+## aep-131-request-body
+
+**Rule** A get method must not accept a request body.
+
+This rule enforces that all standard `Get` operations omit the HTTP `body`, as
+mandated in [AEP-131].
+
+### Details
+
+This rule looks for "get" operations on a path that ends in a path parameter,
+and complains if the 'requestBody' field is present.
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: string
+      responses:
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      summary: Get book
+      responses:
+```
+
+### Disabling
+
+**Important:** HTTP `GET` requests are unable to have an HTTP body, due to the
+nature of the protocol. The only valid way to include a body is to also use a
+different HTTP method.
+
+## aep-131-required-params
+
+**Rule**: Get methods must have no required parameters other than path
+parameters
+
+This rule checks that Get methods have no required parameters other than path
+parameters, as mandated in [AEP-131].
+
+### Details
+
+This rule looks at all Get methods and complains if it finds any required
+parameters that are not path parameters (which must be required).
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1/{id}':
+    get:
+      description: 'Required query parameter'
+      parameters:
+        - name: force
+          in: query
+          required: true
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/books/{id}':
+    get:
+      description: 'Only path params are required'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: force
+          in: query
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: Ok
+          content:
+            'application/json':
+              schema:
+                type: object
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/books/{id}/get'
+    rules:
+      aep-131-required-params: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.
+
+## aep-131-response-body
 
 **Rule**: The response should include the AEP resource.
 
@@ -165,7 +241,81 @@ overrides:
   - files:
       - 'openapi.json#/books/{id}/get/responses/200/content/application/json/schema'
     rules:
-      aep-131-response-schema: 'off'
+      aep-131-response-body: 'off'
+```
+
+If you need to violate this rule for an entire file, add an "override" to the
+Spectral rule file for the specific file without a fragment.
+
+## aep-131-unknown-optional-params
+
+**Rule**: Get methods should have no unknown optional parameters
+
+This rule checks that Get methods have no optional parameters other than
+parameters defined in [AEP-131] or other AEPs.
+
+### Details
+
+This rule looks at the parameters all Get methods, and complains if it finds
+any optional query parameters that are not described in the AEPs. Optional
+parameters allowed on Get methods defined in other AEPs include:
+
+- `read_mask` - defined in [AEP-157]
+- `view` - defined in [AEP-157]
+
+[AEP-157]: https://aep.dev/157/
+
+### Examples
+
+**Incorrect** code for this rule:
+
+```yaml
+paths:
+  '/test1/{id}':
+    get:
+      description: Unknown force optional parameter
+      parameters:
+        - name: force
+          in: query
+          schema:
+            type: boolean
+```
+
+**Correct** code for this rule:
+
+```yaml
+paths:
+  '/publishers/{publisherId}/books/{id}':
+    get:
+      description: No unknown optional params
+      parameters:
+        - name: publisherId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: view
+          in: query
+          schema:
+            enum: ['BASIC', 'FULL']
+```
+
+### Disabling
+
+If you need to violate this rule for a specific operation, add an "override" to
+the Spectral rule file for the specific file and fragment.
+
+```yaml
+overrides:
+  - files:
+      - 'openapi.json#/paths/books/get/{id}/parameters/0'
+    rules:
+      aep-131-unknown-optional-params: 'off'
 ```
 
 If you need to violate this rule for an entire file, add an "override" to the

--- a/test/0131/request-body.test.js
+++ b/test/0131/request-body.test.js
@@ -4,11 +4,11 @@ require('../matchers');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForAepRule('0131', 'aep-131-http-body');
+  linter = await linterForAepRule('0131', 'aep-131-request-body');
   return linter;
 });
 
-test('aep-131-http-body should find errors', () => {
+test('aep-131-request-body should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -36,7 +36,7 @@ test('aep-131-http-body should find errors', () => {
   });
 });
 
-test('aep-131-http-body should find no errors', () => {
+test('aep-131-request-body should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {

--- a/test/0131/required-params.test.js
+++ b/test/0131/required-params.test.js
@@ -1,0 +1,145 @@
+const { linterForAepRule } = require('../utils');
+require('../matchers');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0131', 'aep-131-required-params');
+  return linter;
+});
+
+test('aep-131-required-params should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          parameters: [
+            {
+              name: 'force',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+      '/test2/{id}': {
+        parameters: [
+          {
+            name: 'force',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'boolean',
+            },
+          },
+        ],
+        get: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'get', 'parameters', '0', 'required'],
+      message: 'A standard Get method must not have any required parameters other than path parameters.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2/{id}', 'parameters', '0', 'required'],
+      message: 'A standard Get method must not have any required parameters other than path parameters.',
+    });
+  });
+});
+
+test('aep-131-required-params should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      // No parameters
+      '/test1/{id}': {
+        get: {},
+      },
+      // required path parameters, optional query parameters
+      '/test1/{id1}/test2/{id2}': {
+        get: {
+          parameters: [
+            {
+              name: 'id1',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'id2',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'force',
+              in: 'query',
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+    },
+    // required params in other methods are not flagged
+    '/test3/{id}': {
+      patch: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      post: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      put: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/0131/response-body.test.js
+++ b/test/0131/response-body.test.js
@@ -4,11 +4,11 @@ require('../matchers');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForAepRule('0131', 'aep-131-response-schema');
+  linter = await linterForAepRule('0131', 'aep-131-response-body');
   return linter;
 });
 
-test('aep-131-response-schema should find errors', () => {
+test('aep-131-response-body should find errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {
@@ -74,7 +74,7 @@ test('aep-131-response-schema should find errors', () => {
   });
 });
 
-test('aep-131-response-schema should find no errors', () => {
+test('aep-131-response-body should find no errors', () => {
   const oasDoc = {
     openapi: '3.0.3',
     paths: {

--- a/test/0131/unknown-optional-params.test.js
+++ b/test/0131/unknown-optional-params.test.js
@@ -1,4 +1,3 @@
-const { it } = require('@jest/globals');
 const { linterForAepRule } = require('../utils');
 require('../matchers');
 
@@ -69,11 +68,11 @@ test('aep-131-unknown-optional-params should find no errors', () => {
       },
       // required path parameters, allowed optional parameters
       // optional header parameters
-      '/test1/{testId}/test2/{id}': {
+      '/test1/{test_id}/test2/{id}': {
         get: {
           parameters: [
             {
-              name: 'testId',
+              name: 'test_id',
               in: 'path',
               required: true,
               schema: {

--- a/test/0131/unknown-optional-params.test.js
+++ b/test/0131/unknown-optional-params.test.js
@@ -1,0 +1,159 @@
+const { it } = require('@jest/globals');
+const { linterForAepRule } = require('../utils');
+require('../matchers');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForAepRule('0131', 'aep-131-unknown-optional-params');
+  return linter;
+});
+
+test('aep-131-unknown-optional-params should find errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{id}': {
+        get: {
+          parameters: [
+            {
+              name: 'force',
+              in: 'query',
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+      '/test2/{id}': {
+        parameters: [
+          {
+            name: 'force',
+            in: 'query',
+            schema: {
+              type: 'boolean',
+            },
+          },
+        ],
+        get: {
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results).toContainMatch({
+      path: ['paths', '/test1/{id}', 'get', 'parameters', '0', 'name'],
+      message: 'A standard Get method should not have unknown optional parameters.',
+    });
+    expect(results).toContainMatch({
+      path: ['paths', '/test2/{id}', 'parameters', '0', 'name'],
+      message: 'A standard Get method should not have unknown optional parameters.',
+    });
+  });
+});
+
+test('aep-131-unknown-optional-params should find no errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      // No parameters
+      '/test1/{id}': {
+        patch: {},
+      },
+      // required path parameters, allowed optional parameters
+      // optional header parameters
+      '/test1/{testId}/test2/{id}': {
+        get: {
+          parameters: [
+            {
+              name: 'testId',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'read_mask',
+              in: 'query',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+            {
+              name: 'view',
+              in: 'query',
+              schema: {
+                enum: ['BASIC', 'FULL'],
+              },
+            },
+            {
+              name: 'force',
+              in: 'header',
+              schema: {
+                type: 'boolean',
+              },
+            },
+          ],
+        },
+      },
+    },
+    // optional params in other methods are not flagged
+    '/test3/{id}': {
+      patch: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      post: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+      put: {
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds some rules that are defined for other standard methods but missed for AEP-131, and renames a few rules for consistency with the other standard method rules.

Fixes #29.