### PR TITLE
Restructure docs

### DIFF
--- a/docs/0132.md
+++ b/docs/0132.md
@@ -112,7 +112,7 @@ Spectral rule file for the specific file without a fragment.
 This rule enforces that all `List` standard methods use the correct type for
 any optional parameters described in [AEP-132][].
 
-## Details
+### Details
 
 This rule looks at the query parameters of "get" operations on a path that does
 not end in a path parameter, and complains if it finds
@@ -121,7 +121,7 @@ not end in a path parameter, and complains if it finds
 - a parameter named `order_by` that is not `type: string`
 - a parameter named `show_deleted` that is not `type: boolean`
 
-## Examples
+### Examples
 
 **Incorrect** code for this rule:
 
@@ -149,7 +149,7 @@ paths:
             type: string
 ```
 
-## Disabling
+### Disabling
 
 If you need to violate this rule for a specific operation, add an "override" to
 the Spectral rule file for the specific file and fragment.
@@ -179,7 +179,7 @@ This rule looks at the parameters of "get" operations on a path that does not
 end in a path parameter, and complains if it finds any required parameters that
 are not path parameters (which must be required).
 
-## Examples
+### Examples
 
 **Incorrect** code for this rule:
 
@@ -213,7 +213,7 @@ paths:
             type: boolean
 ```
 
-## Disabling
+### Disabling
 
 If you need to violate this rule for a specific operation, add an "override" to
 the Spectral rule file for the specific file and fragment.


### PR DESCRIPTION
The site-generator assumes that each rule (and only each rule) has a H2. We have a couple subsections that should be H3s.