### PR TITLE
Update regex patterns for x-aep-resource validation

### DIFF
--- a/aep/0004.yaml
+++ b/aep/0004.yaml
@@ -15,7 +15,7 @@ rules:
           properties:
             type:
               type: string
-              pattern: '^[a-z][.-a-z0-9/]*/[a-z][-a-z0-9]*$'
+              pattern: '^[a-z][a-z0-9./-]*/[a-z][a-z0-9-]*$'
             singular:
               type: string
               pattern: '^[a-z][a-z0-9-]*$'
@@ -32,7 +32,7 @@ rules:
               type: array
               items:
                 type: string
-                pattern: '^[a-z][.-a-z0-9/]*/[a-z][-a-z0-9]*$'
+                pattern: '^[a-z][a-z0-9-]*$'
             singleton:
               type: boolean
           additionalProperties: false

--- a/test/0004/structure.test.js
+++ b/test/0004/structure.test.js
@@ -158,7 +158,7 @@ test('aep-0004-x-aep-resource-structure should allow kebab-case in singular and 
           'x-aep-resource': {
             singular: 'book-edition',
             plural: 'book-editions',
-            patterns: ['book-editions/{book-edition_id}'],
+            patterns: ['book-editions/{book_edition_id}'],
           },
         },
       },


### PR DESCRIPTION
The regex patterns from the x-aep-resource schema are missing or incorrect in the 0004.yaml