### PR TITLE
Fix regex pattern for operation ID validation in AEP-144

### DIFF
--- a/aep/0144.yaml
+++ b/aep/0144.yaml
@@ -16,7 +16,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: '^([Aa]dd|[Rr]remove)[A-Z].*$'
+        match: '^([Aa]dd|[Rr]emove)[A-Z].*$'
 
   aep-144-http-method:
     description: An Update Array operation must be POST.


### PR DESCRIPTION
Trivial typo fix